### PR TITLE
adding dremio credential loading

### DIFF
--- a/go_core-local.gophp
+++ b/go_core-local.gophp
@@ -26,6 +26,11 @@ $config = [
         'byuApi' => [
             'key' => '{{.ByuAPIKey}}',
             'secret' => '{{.ByuAPISecret}}'
+        ],
+        'dremioApi' => [
+            'url' => '{{.DremioURL}}',
+            'username' => '{{.DremioUser}}',
+            'password' => '{{.DremioPassword}}'
         ]
     ],
     'github' => [

--- a/go_launcher.go
+++ b/go_launcher.go
@@ -22,6 +22,9 @@ type Config struct {
 	CollibraPassword string
 	ByuAPIKey        string
 	ByuAPISecret     string
+	DremioURL        string
+	DremioUser       string
+	DremioPassword   string
 	GithubToken      string
 	DBHost           string
 	DBUser           string
@@ -62,6 +65,9 @@ func main() {
 		CollibraPassword: params["collibra_password"],
 		ByuAPIKey:        params["byuapi_key"],
 		ByuAPISecret:     params["byuapi_secret"],
+		DremioURL:        params["dremio_url"],
+		DremioUser:       params["dremio_user"],
+		DremioPassword:   params["dremio_password"],
 		GithubToken:      params["github_token"],
 		DBHost:           os.Getenv("DB_ADDRESS"),
 		DBUser:           params["db_username"],


### PR DESCRIPTION
This adds the dremio config to AWS.

Just set the following parameters in Parameter Store:
`/infohub/dev/dremio_user`
`/infohub/dev/dremio_password`
`/infohub/dev/dremio_url`