### PR TITLE
Remove SAML Metadata Field

### DIFF
--- a/app/View/Request/index.ctp
+++ b/app/View/Request/index.ctp
@@ -468,6 +468,7 @@
 						"tables",
 						"virtualTables",
 						"saml",
+						"samlMetadata",
 						Configure::read('Collibra.requiredTermsString'),
 						Configure::read('Collibra.additionalTermsString'),
 						Configure::read('Collibra.requiredElementsString'),


### PR DESCRIPTION
SAML Metadata field should not be visible on DSR form.